### PR TITLE
Adding libevent plus inspec tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.libevent?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=160&branchName=master)
+
+# libevent
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+plan_name : "libevent"

--- a/controls/libevent_test.rb
+++ b/controls/libevent_test.rb
@@ -1,0 +1,34 @@
+title 'Tests to confirm libevent works as expected'
+
+plan_name = input('plan_name', value: 'libevent')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+hab_path = input('hab_path', value: 'hab')
+
+control 'core-plans-libevent' do
+  impact 1.0
+  title 'Ensure libevent is correct'
+  desc '
+  For libevent we check for the presence of a couple of files to ensure the package is
+  correctly installed:  lib/libevent.so and bin/event_rpcgen.py.
+  '
+  libevent_pkg = command("#{hab_path} pkg path #{plan_ident}")
+  describe libevent_pkg do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  libevent_pkg = libevent_pkg.stdout.strip
+
+  describe command("ls -al #{libevent_pkg}/lib/libevent.so") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /#{libevent_pkg}/ }
+    its('stderr') { should be_empty }
+  end
+
+  describe command("ls -al #{libevent_pkg}/bin/event_rpcgen.py") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /#{libevent_pkg}/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
+name: libevent
+title: Habitat Core Plan libevent
 maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
+summary: InSpec controls for testing Habitat Core Plan libevent
 copyright: humans@habitat.sh
 copyright_email: humans@habitat.sh
 version: 0.1.0

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,17 @@
+pkg_origin=core
+pkg_name=libevent
+pkg_version=2.0.22
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('BSD-3-Clause')
+pkg_source=https://github.com/${pkg_name}/${pkg_name}/releases/download/release-${pkg_version}-stable/${pkg_name}-${pkg_version}-stable.tar.gz
+pkg_upstream_url=https://libevent.org
+pkg_description="The libevent API provides a mechanism to execute a callback function when a specific event occurs \
+  on a file descriptor or after a timeout has been reached. Furthermore, libevent also support callbacks due to \
+  signals or regular timeouts."
+pkg_shasum=71c2c49f0adadacfdbe6332a372c38cf9c8b7895bb73dabeaa53cdcc1d4e1fa3
+pkg_dirname=${pkg_name}-${pkg_version}-stable
+pkg_deps=(core/glibc)
+pkg_build_deps=(core/cacerts core/gcc core/make)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)


### PR DESCRIPTION
Migration from core plans plus inspec tests.

```
Profile: Habitat Core Plan libevent (libevent)
Version: 0.1.0
Target:  docker://038c9db402977592ec82acdcf95dc3b27439d16ac169b26f191477f57179350f

  ✔  core-plans-libevent: Ensure libevent is correct
     ✔  Command: `hab pkg path habskp/libevent` exit_status is expected to eq 0
     ✔  Command: `hab pkg path habskp/libevent` stdout is expected not to be empty
     ✔  Command: `ls -al /hab/pkgs/habskp/libevent/2.0.22/20200615105209/lib/libevent.so` exit_status is expected to eq 0
     ✔  Command: `ls -al /hab/pkgs/habskp/libevent/2.0.22/20200615105209/lib/libevent.so` stdout is expected not to be empty
     ✔  Command: `ls -al /hab/pkgs/habskp/libevent/2.0.22/20200615105209/lib/libevent.so` stdout is expected to match /\/hab\/pkgs\/habskp\/libevent\/2.0.22\/20200615105209/
     ✔  Command: `ls -al /hab/pkgs/habskp/libevent/2.0.22/20200615105209/lib/libevent.so` stderr is expected to be empty
     ✔  Command: `ls -al /hab/pkgs/habskp/libevent/2.0.22/20200615105209/bin/event_rpcgen.py` exit_status is expected to eq 0
     ✔  Command: `ls -al /hab/pkgs/habskp/libevent/2.0.22/20200615105209/bin/event_rpcgen.py` stdout is expected not to be empty
     ✔  Command: `ls -al /hab/pkgs/habskp/libevent/2.0.22/20200615105209/bin/event_rpcgen.py` stdout is expected to match /\/hab\/pkgs\/habskp\/libevent\/2.0.22\/20200615105209/
     ✔  Command: `ls -al /hab/pkgs/habskp/libevent/2.0.22/20200615105209/bin/event_rpcgen.py` stderr is expected to be empty


Profile Summary: 1 successful control, 0 control failures, 0 controls skipped
Test Summary: 10 successful, 0 failures, 0 skipped
```

﻿Signed-off-by: Stuart Paterson <spaterson@chef.io>
